### PR TITLE
Add add'l command-line options

### DIFF
--- a/internal/pkg/modulefiles/find.go
+++ b/internal/pkg/modulefiles/find.go
@@ -17,7 +17,7 @@ import (
 )
 
 // Find the set of files that are depended on by the package at root.
-func Find(ctx context.Context, root string, testPaths bool) ([]string, error) {
+func Find(ctx context.Context, root string, testPaths, modFiles bool) ([]string, error) {
 	var errs []error
 
 	files := map[string]struct{}{}
@@ -42,11 +42,13 @@ func Find(ctx context.Context, root string, testPaths bool) ([]string, error) {
 		}))
 	}
 
-	for _, m := range modules {
-		errs = append(errs, m.addRootFiles(files))
-	}
-	if workspace != nil {
-		errs = append(errs, workspace.addRootFiles(files))
+	if modFiles {
+		for _, m := range modules {
+			errs = append(errs, m.addRootFiles(files))
+		}
+		if workspace != nil {
+			errs = append(errs, workspace.addRootFiles(files))
+		}
 	}
 
 	sortedFiles := make([]string, 0, len(files))

--- a/internal/pkg/modulefiles/find_test.go
+++ b/internal/pkg/modulefiles/find_test.go
@@ -20,6 +20,7 @@ type testFindArgs struct {
 	runDir   string   // The path to the entry point in files.
 
 	includeTestFiles bool
+	excludeModFiles  bool
 }
 
 func TestFindWithGoWorkspaceEnclosingTwoModules(t *testing.T) {
@@ -197,7 +198,7 @@ func testFind(t *testing.T, args testFindArgs) {
 	}
 
 	// Run the Find function
-	files, err := Find(ctx, path.Join(tmpDir, args.runDir), args.includeTestFiles)
+	files, err := Find(ctx, path.Join(tmpDir, args.runDir), args.includeTestFiles, !args.excludeModFiles)
 	if assert.NoError(t, err) {
 		assert.ElementsMatch(t, args.expected, display.Relative(ctx, tmpDir, files))
 	}
@@ -222,6 +223,30 @@ func main() {
 		},
 		expected: []string{
 			"go.mod",
+			"main.go",
+		},
+	})
+}
+
+func TestFindSinglePackageNoMod(t *testing.T) {
+	t.Parallel()
+	testFind(t, testFindArgs{
+		excludeModFiles: true,
+		files: map[string]string{
+			"go.mod": `module example.com/testmod
+
+go 1.18
+`,
+			"main.go": `package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, World!")
+}
+`,
+		},
+		expected: []string{
 			"main.go",
 		},
 	})


### PR DESCRIPTION
- Add a flag to disable the inclusion of go.mod, etc. for scenarios that capture module dependencies via distinct targets
- Add a flag to output the list of sources as a JSON array rather than a space-separates list of strings
- Add a flag to output absolute paths rather than relative paths

These changes enable additional scenarios and tighter integration with other build environmnents.