### PR TITLE
Perf find in parallel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 bin
+tmp
+.make

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+# Contributing to `helpmakego`
+
+## Building
+
+`make build` will do everything, and put the resulting binary into `bin/helpmakego`.
+
+## Tests
+
+`make test` will run all tests.
+
+## Benchmarks
+
+Developers are busy people, and speed is *critical* to keeping `helpmakego` out of their way.
+
+Any change to the hot loop of finding packages must come with benchmark results showing
+that it doesn't decrease performance for users.
+
+I like to use [`hyperfine`]() for checking performance. Running `make benchmark` will
+generate a benchmark report comparing the local build of `helpmakego` with the version
+currently on master.

--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,31 @@ lint:
 
 test:
 	go test -v ./...
+
+.PHONY: benchmark
+benchmark: build tmp/helpmakego-main/bin/helpmakego \
+		.make/tmp/pulumi
+
+	$(call bench,tmp/pulumi/pkg/cmd/pulumi)
+
+define bench
+	hyperfine --warmup 5 \
+		--command-name main 'tmp/helpmakego-main/bin/helpmakego $(1)' \
+		--command-name current 'bin/helpmakego $(1)'
+endef
+
+tmp/helpmakego-main/bin/helpmakego:
+	@mkdir -p tmp
+	git clone --depth=1 --branch main "https://github.com/iwahbe/helpmakego.git" tmp/helpmakego-main
+	make -C tmp/helpmakego-main build
+
+.make/tmp/pulumi:
+	@mkdir -p .make/tmp/
+	rm -rf tmp/pulumi
+	git clone --depth=1 --branch v3.154.0 "https://github.com/pulumi/pulumi.git" tmp/pulumi
+	@touch $@
+
+clean:
+	rm -rf tmp
+	rm -rf bin
+	rm -rf .make


### PR DESCRIPTION
Running `helpmakego` in large makefiles (20 targets - each one a large go code base) gets pretty slow. I am seeing 2-4s to parse the Makefile (generating all targets).

This change moves the package parsing code from a stack-based depth first search to a fully parallel traversal.


This change leads to a 2-3x improvement in runtime performance on our current benchmark:

```
make benchmark                 
hyperfine --warmup 5 --command-name main 'tmp/helpmakego-main/bin/helpmakego tmp/pulumi/pkg/cmd/pulumi' --command-name current 'bin/helpmakego tmp/pulumi/pkg/cmd/pulumi'
Benchmark #1: main
  Time (mean ± σ):      73.5 ms ±   1.6 ms    [User: 104.2 ms, System: 27.0 ms]
  Range (min … max):    71.2 ms …  79.3 ms    34 runs
 
Benchmark #2: current
  Time (mean ± σ):      26.2 ms ±   1.4 ms    [User: 117.1 ms, System: 60.1 ms]
  Range (min … max):    22.7 ms …  30.3 ms    73 runs
 
Summary
  'current' ran
    2.80 ± 0.16 times faster than 'main'
```

I have observed the same change in multiple other repos.