### PR TITLE
Fix replace discovery when replace statements prefix one another

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,14 @@ test:
 
 .PHONY: benchmark
 benchmark: build tmp/helpmakego-main/bin/helpmakego \
-		.make/tmp/pulumi
+		.make/tmp/pulumi \
+		.make/tmp/kubernetes
+
+	cd tmp/helpmakego-main && git pull
+	make -C tmp/helpmakego-main build
 
 	$(call bench,tmp/pulumi/pkg/cmd/pulumi)
+	$(call bench,tmp/kubernetes/cmd/kubectl)
 
 define bench
 	hyperfine --warmup 5 \
@@ -27,12 +32,17 @@ endef
 tmp/helpmakego-main/bin/helpmakego:
 	@mkdir -p tmp
 	git clone --depth=1 --branch main "https://github.com/iwahbe/helpmakego.git" tmp/helpmakego-main
-	make -C tmp/helpmakego-main build
 
 .make/tmp/pulumi:
 	@mkdir -p .make/tmp/
 	rm -rf tmp/pulumi
 	git clone --depth=1 --branch v3.154.0 "https://github.com/pulumi/pulumi.git" tmp/pulumi
+	@touch $@
+
+.make/tmp/kubernetes:
+	@mkdir -p .make/tmp/
+	rm -rf tmp/kubernetes
+	git clone --depth=1 --branch v1.32.2 "https://github.com/kubernetes/kubernetes.git" tmp/kubernetes
 	@touch $@
 
 clean:

--- a/internal/pkg/modulefiles/find.go
+++ b/internal/pkg/modulefiles/find.go
@@ -354,7 +354,13 @@ func (pf *packageFinder) findPackages(ctx context.Context, target string) {
 
 	pkg, err := build.Default.ImportDir(target, 0)
 	if err != nil {
-		pf.cancel(err)
+		if _, err := os.Stat(target); os.IsNotExist(err) {
+			log.Error(ctx, "Targeted missing directory, maybe a replace was missed")
+			pf.cancel(fmt.Errorf("referenced target %q does not exist: %w", target, err))
+			return
+		}
+
+		pf.cancel(fmt.Errorf("cannot import dir: %w", err))
 		return
 	}
 	pf.dst <- pkg


### PR DESCRIPTION
This PR fixes a bug with replace path checking. 

## The bug

Previously, replace paths could cover other replace paths that they prefixed. For an example, consider these replace statements:

```
	k8s.io/api => ./staging/src/k8s.io/api
	k8s.io/apimachinery => ./staging/src/k8s.io/apimachinery
```

Package imports like `k8s.io/apimachinery/pkg/util/net` were being translated to `./staging/src/k8s.io/api/pkg/util/net`.

This PR fixes that issue.