### PR TITLE
Enable the daemon by default

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -17,7 +17,10 @@ import (
 	"github.com/iwahbe/helpmakego/internal/pkg/modulefiles"
 )
 
-var useDaemon = isTruthy(os.Getenv("HELPMAKEGO_EXPERIMENT_DAEMON"))
+var useDaemon = func() bool {
+	envVar := os.Getenv("HELPMAKEGO_DAEMON")
+	return !(strings.EqualFold(envVar, "false") || envVar == "0")
+}()
 
 func Root() *cobra.Command {
 	cmd := &cobra.Command{
@@ -108,5 +111,3 @@ func Root() *cobra.Command {
 
 	return cmd
 }
-
-func isTruthy(s string) bool { return strings.EqualFold(s, "true") || s == "1" }


### PR DESCRIPTION
The daemon can still be disabled by setting `HELPMAKEGO_DAEMON="false"`.