### PR TITLE
Do not race when importing a directory

### DIFF
--- a/internal/pkg/modulefiles/cache.go
+++ b/internal/pkg/modulefiles/cache.go
@@ -25,27 +25,16 @@ func NewCache(ctx context.Context, pkgRoot string) (Cache, error) {
 type cachedImporter struct{ packages *sync.Map }
 
 func (c cachedImporter) ImportDir(dir string, mode build.ImportMode) (*build.Package, error) {
-	type (
-		key struct {
-			dir  string
-			mode build.ImportMode
-		}
-		value struct {
-			pkg *build.Package
-			err error
-		}
-	)
-
-	k := key{dir, mode}
-	v, ok := c.packages.Load(k)
-	if !ok {
-		pkg, err := build.Default.ImportDir(dir, mode)
-		v, _ = c.packages.LoadOrStore(k, value{pkg, err})
+	type key struct {
+		dir  string
+		mode build.ImportMode
 	}
 
-	val := v.(value)
-	return val.pkg, val.err
-
+	k := key{dir, mode}
+	v, _ := c.packages.LoadOrStore(k, sync.OnceValues(func() (*build.Package, error) {
+		return build.Default.ImportDir(dir, mode)
+	}))
+	return v.(func() (*build.Package, error))()
 }
 
 func (c Cache) getModules(key lookupKey) *modules {


### PR DESCRIPTION
When importing a directory with the `cachedImporter`, it was possible to race an import when multiple packages depend on a third package. The cached package load logic was:

```go
func (c cachedImporter) ImportDir(dir string, mode build.ImportMode) (*build.Package, error) {
	type (
		key struct {
			dir  string
			mode build.ImportMode
		}
		value struct {
			pkg *build.Package
			err error
		}
	)

	k := key{dir, mode}
	v, ok := c.packages.Load(k)
	if !ok {
		pkg, err := build.Default.ImportDir(dir, mode)
		v, _ = c.packages.LoadOrStore(k, value{pkg, err})
	}

	val := v.(value)
	return val.pkg, val.err

}
```

This allows for a race condition where `build.Default.ImportDir` can be called on the same package multiple times. The race is benign on mac and linux, since only the first to finish result will be used and since `build.Default.ImportDir` is a read only operation.

On windows, this race **may** cause https://github.com/pulumi/pulumi/issues/21304, since it would allow for multiple concurrent reads of the same file. Multiple concurrent reads will result in at least 1 error in Windows, which would return early and cause `helpmakego` to error.