### PR TITLE
Add `--packages`

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -24,7 +25,7 @@ var useDaemon = func() bool {
 
 func Root() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "helpmakego [path-to-package] [--test] [--abs] [--mod]",
+		Use:          "helpmakego [path-to-package] [--test] [--abs] [--mod] [--packages]",
 		Short:        "Find all files a Go package depends on - suitable for Make",
 		SilenceUsage: true,
 		Args:         cobra.MaximumNArgs(1),
@@ -34,10 +35,21 @@ func Root() *cobra.Command {
 	outputJSON := cmd.Flags().Bool("json", false, "output source files as a a JSON array")
 	absolutePaths := cmd.Flags().Bool("abs", false, "output absolute paths instead of relative paths")
 	includeMod := cmd.Flags().Bool("mod", true, "include module files in the result")
+	packages := cmd.Flags().Bool("packages", false, "emit packages instead of files")
 
 	isDaemon := cmd.Flags().Bool("x-daemon", false, "do not run the normal process, run as a daemon")
 	cmd.Flag("x-daemon").Hidden = true
 
+	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+		if *packages {
+			if cmd.Flags().Changed("mod") && *includeMod {
+				return errors.New("--packages implies --mod=false")
+			}
+			*includeMod = false
+		}
+
+		return nil
+	}
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
 
@@ -88,7 +100,12 @@ func Root() *cobra.Command {
 			find = daemon.Find
 		}
 
-		paths, err := find(ctx, pkgPath, *includeTest, *includeMod, os.Getenv("GOWORK") != "off")
+		paths, err := find(ctx, pkgPath, modulefiles.FindArgs{
+			TestPaths:    *includeTest,
+			ModFiles:     *includeMod,
+			GoWork:       os.Getenv("GOWORK") != "off",
+			EmitPackages: *packages,
+		})
 		if err != nil {
 			return err
 		}

--- a/internal/pkg/daemon/daemon.go
+++ b/internal/pkg/daemon/daemon.go
@@ -95,7 +95,7 @@ func socketPath(moduleRoot string) string {
 
 // Find delegates a find call to the running daemon, or it executes the call locally and
 // while starting the daemon.
-func Find(ctx context.Context, pkgRoot string, includeTests, includeMod, goWork bool) ([]string, error) {
+func Find(ctx context.Context, pkgRoot string, args modulefiles.FindArgs) ([]string, error) {
 	moduleRoot, err := modulefiles.FindModuleRoot(ctx, pkgRoot)
 	if err != nil {
 		return nil, err
@@ -113,10 +113,10 @@ func Find(ctx context.Context, pkgRoot string, includeTests, includeMod, goWork 
 	case errors.Is(err, os.ErrNotExist):
 		go start(ctx, moduleRoot) // Start the daemon in the background for the next invocation
 		log.Info(ctx, "starting daemon for next run")
-		return modulefiles.Find(ctx, pkgRoot, includeTests, includeMod, goWork)
+		return modulefiles.Find(ctx, pkgRoot, args)
 	case errors.Is(err, os.ErrPermission):
 		log.Warn(ctx, "permission denied to start daemon", log.Attr("error", err.Error()))
-		return modulefiles.Find(ctx, pkgRoot, includeTests, includeMod, goWork)
+		return modulefiles.Find(ctx, pkgRoot, args)
 	default:
 		return nil, fmt.Errorf("unexpected dial error for find daemon: %w", err)
 	}
@@ -125,8 +125,10 @@ func Find(ctx context.Context, pkgRoot string, includeTests, includeMod, goWork 
 	enc.SetEscapeHTML(false)
 	err = enc.Encode(request{
 		PathToPackage: pkgRoot,
-		IncludeTest:   includeTests,
-		IncludeMod:    includeMod,
+		IncludeTest:   args.TestPaths,
+		IncludeMod:    args.ModFiles,
+		GoWork:        args.GoWork,
+		EmitPackages:  args.EmitPackages,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode request: %w", err)
@@ -160,7 +162,12 @@ func handle(ctx context.Context, cache modulefiles.Cache, conn net.Conn) {
 	}
 
 	// Execute find from the shared cache
-	files, err := cache.Find(ctx, req.PathToPackage, req.IncludeTest, req.IncludeMod, req.GoWork)
+	files, err := cache.Find(ctx, req.PathToPackage, modulefiles.FindArgs{
+		TestPaths:    req.IncludeTest,
+		ModFiles:     req.IncludeMod,
+		GoWork:       req.GoWork,
+		EmitPackages: req.EmitPackages,
+	})
 
 	// Write the response
 	enc := json.NewEncoder(conn)
@@ -183,6 +190,7 @@ type request struct {
 	IncludeTest   bool   `json:"includeTest"`
 	IncludeMod    bool   `json:"includeMod"`
 	GoWork        bool   `json:"goWork"`
+	EmitPackages  bool   `json:"emitPackages"`
 }
 
 type response struct {

--- a/internal/pkg/daemon/daemon_test.go
+++ b/internal/pkg/daemon/daemon_test.go
@@ -57,7 +57,10 @@ func TestDaemon(t *testing.T) {
 	require.True(t, socketExists, "daemon socket was not created: %s", socketPath)
 
 	// Test daemon.Find - should connect to running daemon
-	files, err := Find(ctx, tmpDir, false, true, true)
+	files, err := Find(ctx, tmpDir, modulefiles.FindArgs{
+		ModFiles: true,
+		GoWork:   true,
+	})
 	require.NoError(t, err)
 	require.NotEmpty(t, files)
 	assert.Equal(t, []string{

--- a/internal/pkg/daemon/daemon_windows.go
+++ b/internal/pkg/daemon/daemon_windows.go
@@ -21,6 +21,6 @@ func Serve(ctx context.Context, pkgRoot string) error {
 	return errors.New("daemon is not supported on Windows")
 }
 
-func Find(ctx context.Context, pkgRoot string, includeTests, includeMod, goWork bool) ([]string, error) {
-	return modulefiles.Find(ctx, pkgRoot, includeTests, includeMod, goWork)
+func Find(ctx context.Context, pkgRoot string, args modulefiles.FindArgs) ([]string, error) {
+	return modulefiles.Find(ctx, pkgRoot, args)
 }

--- a/internal/pkg/modulefiles/cache.go
+++ b/internal/pkg/modulefiles/cache.go
@@ -46,12 +46,13 @@ func (c Cache) getModules(key lookupKey) *modules {
 	return k.(*modules)
 }
 
-func (c Cache) Find(ctx context.Context, pkg string, testPaths, modFiles, goWork bool) ([]string, error) {
-	return findWithModules(ctx, pkg, testPaths, modFiles, goWork, c.getModules(lookupKey{
-		test: testPaths,
-		mod:  modFiles,
-		work: goWork,
-	}), c.packages)
+func (c Cache) Find(ctx context.Context, pkg string, args FindArgs) ([]string, error) {
+	return findWithModules(ctx, pkg, args.TestPaths, args.ModFiles, args.GoWork, args.EmitPackages,
+		c.getModules(lookupKey{
+			test: args.TestPaths,
+			mod:  args.ModFiles,
+			work: args.GoWork,
+		}), c.packages)
 }
 
 func (c Cache) ModuleRoot() string { return c.modRoot }

--- a/internal/pkg/modulefiles/find.go
+++ b/internal/pkg/modulefiles/find.go
@@ -18,14 +18,28 @@ import (
 )
 
 // Find the set of files that are depended on by the package at root.
-func Find(ctx context.Context, root string, testPaths, modFiles, goWork bool) ([]string, error) {
-	return findWithModules(ctx, root, testPaths, modFiles, goWork, new(modules), &build.Default)
+func Find(ctx context.Context, root string, args FindArgs) ([]string, error) {
+	return findWithModules(ctx, root,
+		args.TestPaths, args.ModFiles, args.GoWork, args.EmitPackages,
+		new(modules), &build.Default)
+}
+
+type FindArgs struct {
+	// If test files & their dependents should be included
+	TestPaths bool
+	// If go.mod & go.sum files should be included
+	ModFiles bool
+	// If go.work & go.work.sum files should be included
+	GoWork bool
+	// If packages should be emitted instead of individual files
+	EmitPackages bool
 }
 
 // Find the set of files that are depended on by the package at root.
 func findWithModules(
 	ctx context.Context, root string,
-	testPaths, modFiles, goWork bool,
+	testPaths, modFiles, goWork,
+	packagesOnly bool,
 	modules *modules, importer interface {
 		ImportDir(string, build.ImportMode) (*build.Package, error)
 	},
@@ -49,7 +63,7 @@ func findWithModules(
 			continue
 		}
 
-		errs = append(errs, importPackage(ctx, pkg, testPaths, func(fileName string) {
+		errs = append(errs, importPackage(ctx, pkg, testPaths, packagesOnly, func(fileName string) {
 			files[filepath.Join(pkg.Dir, fileName)] = struct{}{}
 		}))
 	}
@@ -72,8 +86,12 @@ func findWithModules(
 	return sortedFiles, errors.Join(errs...)
 }
 
-func importPackage(ctx context.Context, pkg *build.Package, includeTests bool, addFile addFile) error {
+func importPackage(ctx context.Context, pkg *build.Package, includeTests, packagesOnly bool, addFile addFile) error {
 	var errs []error
+	if packagesOnly {
+		addFile("")
+		return nil
+	}
 	errs = append(errs, expandEmbeds(ctx, os.DirFS(pkg.Dir), pkg.EmbedPatterns, addFile))
 	if includeTests {
 		// Include test files

--- a/internal/pkg/modulefiles/find_test.go
+++ b/internal/pkg/modulefiles/find_test.go
@@ -20,6 +20,7 @@ type testFindArgs struct {
 
 	includeTestFiles bool
 	excludeModFiles  bool
+	emitPackages     bool
 }
 
 func testFind(t *testing.T, args testFindArgs) {
@@ -40,7 +41,12 @@ func testFind(t *testing.T, args testFindArgs) {
 	}
 
 	// Run the Find function
-	files, err := Find(ctx, path.Join(tmpDir, args.runDir), args.includeTestFiles, !args.excludeModFiles, true /* GOWORK != off */)
+	files, err := Find(ctx, path.Join(tmpDir, args.runDir), FindArgs{
+		TestPaths:    args.includeTestFiles,
+		ModFiles:     !args.excludeModFiles,
+		GoWork:       true, // GOWORK != off
+		EmitPackages: args.emitPackages,
+	})
 	if assert.NoError(t, err) {
 		assert.ElementsMatch(t, args.expected, display.Relative(ctx, tmpDir, files))
 	}
@@ -309,6 +315,44 @@ func Message() string {
 			"go.mod",
 			"main.go",
 			filepath.Join("pkg", "pkg.go"),
+		},
+	})
+}
+
+func TestFindEmitPackages(t *testing.T) {
+	t.Parallel()
+	testFind(t, testFindArgs{
+		emitPackages:    true,
+		excludeModFiles: true,
+		files: map[string]string{
+			"go.mod": `module example.com/testmod
+
+go 1.18
+`,
+			"main.go": `package main
+
+import (
+	"example.com/testmod/pkg"
+)
+
+func main() { pkg.Message() }
+`,
+			"pkg/pkg.go": `package pkg
+
+func Message() string {
+	return "Hello from pkg!"
+}
+`,
+			"pkg/helper.go": `package pkg
+
+func Helper() string {
+	return "helper"
+}
+`,
+		},
+		expected: []string{
+			".",
+			"pkg",
 		},
 	})
 }


### PR DESCRIPTION
Add the ability to limit the output to just the packages required by a package, instead of every file required by the package.