### PR TITLE
Add `--changed-since REF`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,67 @@ $ go tool github.com/iwahbe/helpmakego cmd/myprogram
 cmd/myprogram/main.go go.mod go.sum
 ```
 
+### Restricting output with `--changed-since <ref>`
+
+`--changed-since <ref>` restricts the output to only the parts of the dependency
+set that *could have changed* since `<ref>`. `<ref>` is any revision your version
+control system understands, for example `--changed-since origin/master`,
+`--changed-since HEAD~2`, a tag, or a commit hash.
+
+#### What counts as changed
+
+A **file** is changed if it differs between `<ref>` and your current working tree.
+This is the *net* difference and includes:
+
+- files changed by commits between `<ref>` and your working tree,
+- uncommitted changes, both staged and unstaged,
+- untracked files.
+
+Because it is the net difference, a file that was edited in an intervening commit
+but then reverted back to its `<ref>` contents does *not* count as changed.
+
+#### Changes propagate to importers
+
+A change to a package can change the compiled output of every package that
+imports it, so `helpmakego` emits a changed package **and every package that
+transitively imports it**.
+
+Given `A <- B <- main` (`B` imports `A`, `main` imports `B`):
+
+- editing a file in `A` emits `A`, `B`, and `main`,
+- editing a file only in `main` emits just `main`.
+
+#### Module changes
+
+A change to `go.mod` is handled specially. Bumping a dependency's version, or
+adding, changing, or removing a `replace`, can change the compiled output of
+every package that imports the affected dependency, even when no local source
+file of those packages changed.
+
+`helpmakego` reads `go.mod` as it was at `<ref>` and compares it to the current
+`go.mod`. For every required module whose effective version or `replace` differs,
+every package that transitively imports that module is treated as changed.
+
+#### Local `replace` directives
+
+A `replace` that points at a local directory is tracked by its files rather than
+its version, so a `go.mod` version change for a locally replaced module is
+ignored — only the files in the replacement directory decide whether it changed.
+
+- When the directory is in the **same repository** as the entry module, its files
+  are already part of the repository's change set, so nothing special is needed.
+- When the directory is in a **separate repository**, that repository is diffed on
+  its own. The starting revision comes from the version the requiring `go.mod`
+  pinned at `<ref>` (every `replace` still carries a `require`): a released version
+  maps to its tag, and a pseudo-version maps to the commit it encodes. Any file
+  that changed in the replacement repository between that revision and its current
+  working tree marks the corresponding package as changed, and the change
+  propagates to importers as usual.
+
+If a separate replacement repository cannot be diffed precisely — it is not a
+recognized repository, or the pinned revision cannot be resolved — every package
+under it is treated as changed.
+
 ## How it Works
 
 `helpmakego` is a tool designed to resolve dependencies for Go projects, making it easier

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -25,7 +25,7 @@ var useDaemon = func() bool {
 
 func Root() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "helpmakego [path-to-package] [--test] [--abs] [--mod] [--packages]",
+		Use:          "helpmakego [path-to-package] [--test] [--abs] [--mod] [--changed-since] [--packages]",
 		Short:        "Find all files a Go package depends on - suitable for Make",
 		SilenceUsage: true,
 		Args:         cobra.MaximumNArgs(1),
@@ -35,12 +35,14 @@ func Root() *cobra.Command {
 	outputJSON := cmd.Flags().Bool("json", false, "output source files as a a JSON array")
 	absolutePaths := cmd.Flags().Bool("abs", false, "output absolute paths instead of relative paths")
 	includeMod := cmd.Flags().Bool("mod", true, "include module files in the result")
+	changedSince := cmd.Flags().String("changed-since", "", "only include files in packages that could have changed since the passed REF was included. This includes any dirty files as well as files changed in intervening commits")
 	packages := cmd.Flags().Bool("packages", false, "emit packages instead of files")
 
 	isDaemon := cmd.Flags().Bool("x-daemon", false, "do not run the normal process, run as a daemon")
 	cmd.Flag("x-daemon").Hidden = true
 
 	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+		var errs []error
 		if *packages {
 			if cmd.Flags().Changed("mod") && *includeMod {
 				return errors.New("--packages implies --mod=false")
@@ -48,7 +50,7 @@ func Root() *cobra.Command {
 			*includeMod = false
 		}
 
-		return nil
+		return errors.Join(errs...)
 	}
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
@@ -105,6 +107,7 @@ func Root() *cobra.Command {
 			ModFiles:     *includeMod,
 			GoWork:       os.Getenv("GOWORK") != "off",
 			EmitPackages: *packages,
+			ChangedSince: *changedSince,
 		})
 		if err != nil {
 			return err

--- a/internal/pkg/daemon/daemon.go
+++ b/internal/pkg/daemon/daemon.go
@@ -129,6 +129,7 @@ func Find(ctx context.Context, pkgRoot string, args modulefiles.FindArgs) ([]str
 		IncludeMod:    args.ModFiles,
 		GoWork:        args.GoWork,
 		EmitPackages:  args.EmitPackages,
+		ChangedSince:  args.ChangedSince,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode request: %w", err)
@@ -167,6 +168,7 @@ func handle(ctx context.Context, cache modulefiles.Cache, conn net.Conn) {
 		ModFiles:     req.IncludeMod,
 		GoWork:       req.GoWork,
 		EmitPackages: req.EmitPackages,
+		ChangedSince: req.ChangedSince,
 	})
 
 	// Write the response
@@ -191,6 +193,7 @@ type request struct {
 	IncludeMod    bool   `json:"includeMod"`
 	GoWork        bool   `json:"goWork"`
 	EmitPackages  bool   `json:"emitPackages"`
+	ChangedSince  string `json:"changedSince"`
 }
 
 type response struct {

--- a/internal/pkg/modulefiles/cache.go
+++ b/internal/pkg/modulefiles/cache.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"go/build"
 	"sync"
+
+	"github.com/iwahbe/helpmakego/internal/pkg/vcs"
 )
 
 type Cache struct {
@@ -47,7 +49,7 @@ func (c Cache) getModules(key lookupKey) *modules {
 }
 
 func (c Cache) Find(ctx context.Context, pkg string, args FindArgs) ([]string, error) {
-	return findWithModules(ctx, pkg, args.TestPaths, args.ModFiles, args.GoWork, args.EmitPackages,
+	return findWithModules(ctx, pkg, args, vcs.Discover,
 		c.getModules(lookupKey{
 			test: args.TestPaths,
 			mod:  args.ModFiles,

--- a/internal/pkg/modulefiles/changed.go
+++ b/internal/pkg/modulefiles/changed.go
@@ -1,0 +1,380 @@
+package modulefiles
+
+import (
+	"context"
+	"errors"
+	"maps"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/iwahbe/helpmakego/internal/pkg/log"
+	"github.com/iwahbe/helpmakego/internal/pkg/vcs"
+	"golang.org/x/mod/modfile"
+	xmodule "golang.org/x/mod/module"
+)
+
+// discoverFunc resolves a directory to the version control repository that
+// contains it. [vcs.Discover] satisfies it; tests substitute a fake.
+type discoverFunc func(ctx context.Context, dir string) (vcs.Repo, error)
+
+// importGraph records, for each package directory, the imports it declares.
+//
+// It is written concurrently while packages are discovered and read once
+// discovery is complete.
+type importGraph struct {
+	mu    sync.Mutex
+	edges map[string][]graphEdge
+}
+
+// graphEdge is a single import declared by a package.
+type graphEdge struct {
+	// importPath is the path as written in the source.
+	importPath string
+	// dir is the local directory that provides the import, or "" when the import
+	// is foreign (an external module).
+	dir string
+}
+
+func newImportGraph() *importGraph {
+	return &importGraph{edges: map[string][]graphEdge{}}
+}
+
+func (g *importGraph) add(importer, importPath, dir string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.edges[importer] = append(g.edges[importer], graphEdge{importPath: importPath, dir: dir})
+}
+
+func (g *importGraph) snapshot() map[string][]graphEdge {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	out := make(map[string][]graphEdge, len(g.edges))
+	maps.Copy(out, g.edges)
+	return out
+}
+
+// affectedPackages returns the directories of the packages that could have
+// changed since ref.
+//
+// A package is affected if one of its contributing files changed, if it imports
+// an external module whose go.mod entry changed, or if it transitively imports
+// such a package. Local replaces into a separate repository are diffed in that
+// repository from the revision the requiring go.mod pinned at ref.
+func affectedPackages(
+	ctx context.Context, root, ref string, discover discoverFunc,
+	pkgFiles map[string]map[string]struct{}, graph *importGraph, modules *modules,
+) (map[string]struct{}, error) {
+	repo, err := discover(ctx, root)
+	if err != nil {
+		return nil, err
+	}
+
+	changedList, err := repo.ChangedFiles(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
+	changed := make(map[string]struct{}, len(changedList))
+	for _, file := range changedList {
+		changed[file] = struct{}{}
+	}
+
+	entry, err := modules.findGoMod(ctx, root)
+	if err != nil {
+		return nil, err
+	}
+
+	// Replaces into a separate repository are invisible to the main diff, so diff
+	// each one in its own repository and fold the results in. Replacements we
+	// cannot diff precisely are included wholesale.
+	crossChanged, conservative := crossRepoChanges(ctx, repo, discover, ref, entry)
+	for _, file := range crossChanged {
+		changed[file] = struct{}{}
+	}
+
+	seeds := map[string]struct{}{}
+
+	// Seed with packages whose own files changed.
+	for dir, files := range pkgFiles {
+		if _, ok := changed[dir]; ok || underAny(dir, conservative) {
+			seeds[dir] = struct{}{}
+			continue
+		}
+		for file := range files {
+			if _, ok := changed[file]; ok {
+				seeds[dir] = struct{}{}
+				break
+			}
+		}
+	}
+
+	// Seed with packages importing an external module whose go.mod entry changed.
+	changedModules, err := changedModulePaths(ctx, repo, ref, modules)
+	if err != nil {
+		return nil, err
+	}
+	if len(changedModules) > 0 {
+		for importer, edges := range graph.snapshot() {
+			for _, edge := range edges {
+				if edge.dir == "" && coversAny(edge.importPath, changedModules) {
+					seeds[importer] = struct{}{}
+					break
+				}
+			}
+		}
+	}
+
+	return closeOverImporters(seeds, graph), nil
+}
+
+// crossRepoChanges diffs every local replace whose target lives in a different
+// repository than the entry module.
+//
+// The diff is anchored at the revision the requiring go.mod pinned at ref: the
+// require version is translated to a VCS tag or, for a pseudo-version, the commit
+// it encodes. A replace that cannot be diffed precisely is returned as a
+// conservative directory whose packages are all treated as changed.
+func crossRepoChanges(
+	ctx context.Context, repo vcs.Repo, discover discoverFunc, ref string, entry module,
+) (changed []string, conservative []string) {
+	oldRequire, anchored := requireVersionsAtRef(ctx, repo, ref, entry)
+
+	for _, r := range entry.file.Replace {
+		if !modfile.IsDirectoryPath(r.New.Path) {
+			continue
+		}
+		dir := filepath.Join(entry.rootDir, r.New.Path)
+
+		subRepo, err := discover(ctx, dir)
+		if err != nil {
+			log.Warn(ctx, "cannot resolve repository for local replace; treating all of its files as changed",
+				log.Attr("module", r.Old.Path), log.Attr("dir", dir), log.Attr("error", err.Error()))
+			conservative = append(conservative, dir)
+			continue
+		}
+		if subRepo.Root() == repo.Root() {
+			continue // Same repository; already covered by the main diff.
+		}
+
+		version := oldRequire[r.Old.Path]
+		switch {
+		case !anchored:
+			// The entry go.mod could not be read at ref, so there is no anchor.
+			conservative = append(conservative, dir)
+			continue
+		case version == "":
+			// Not required at ref: a brand new dependency the module diff handles.
+			continue
+		}
+
+		rev, err := versionToRevision(version)
+		if err != nil {
+			log.Warn(ctx, "cannot translate module version to a revision; treating all of its files as changed",
+				log.Attr("module", r.Old.Path), log.Attr("version", version), log.Attr("error", err.Error()))
+			conservative = append(conservative, dir)
+			continue
+		}
+		files, err := subRepo.ChangedFiles(ctx, rev)
+		if err != nil {
+			log.Warn(ctx, "cannot diff local replace repository; treating all of its files as changed",
+				log.Attr("module", r.Old.Path), log.Attr("dir", dir),
+				log.Attr("revision", rev), log.Attr("error", err.Error()))
+			conservative = append(conservative, dir)
+			continue
+		}
+		changed = append(changed, files...)
+	}
+	return changed, conservative
+}
+
+// requireVersionsAtRef reads the entry module's go.mod as of ref and maps each
+// required module path to its version. The second result is false when the
+// go.mod could not be read, meaning no revision can be anchored.
+func requireVersionsAtRef(
+	ctx context.Context, repo vcs.Repo, ref string, entry module,
+) (map[string]string, bool) {
+	rel, err := filepath.Rel(repo.Root(), filepath.Join(entry.rootDir, "go.mod"))
+	if err != nil {
+		return nil, false
+	}
+	bytes, err := repo.ReadFileAtRef(ctx, ref, rel)
+	if err != nil {
+		return nil, false
+	}
+	file, err := modfile.Parse("go.mod", bytes, nil)
+	if err != nil {
+		return nil, false
+	}
+	versions := make(map[string]string, len(file.Require))
+	for _, r := range file.Require {
+		versions[r.Mod.Path] = r.Mod.Version
+	}
+	return versions, true
+}
+
+// versionToRevision translates a module version into the VCS revision it refers
+// to: the commit encoded in a pseudo-version, or the tag named by a released
+// version.
+func versionToRevision(version string) (string, error) {
+	if xmodule.IsPseudoVersion(version) {
+		return xmodule.PseudoVersionRev(version)
+	}
+	// A tag carries no build metadata, so drop suffixes like "+incompatible".
+	if i := strings.IndexByte(version, '+'); i >= 0 {
+		version = version[:i]
+	}
+	return version, nil
+}
+
+// underAny reports whether dir is one of roots or nested within one of them.
+func underAny(dir string, roots []string) bool {
+	for _, root := range roots {
+		if dir == root || strings.HasPrefix(dir, root+string(os.PathSeparator)) {
+			return true
+		}
+	}
+	return false
+}
+
+// changedModulePaths returns the set of module paths whose go.mod resolution
+// differs between ref and the working tree across every discovered module.
+func changedModulePaths(
+	ctx context.Context, repo vcs.Repo, ref string, modules *modules,
+) (map[string]struct{}, error) {
+	changed := map[string]struct{}{}
+	seen := map[string]struct{}{}
+	var errs []error
+
+	for _, v := range (*sync.Map)(modules).Range {
+		mod := v.(module)
+		if _, ok := seen[mod.rootDir]; ok {
+			continue
+		}
+		seen[mod.rootDir] = struct{}{}
+
+		rel, err := filepath.Rel(repo.Root(), filepath.Join(mod.rootDir, "go.mod"))
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		if strings.HasPrefix(rel, "..") {
+			// The module lives in a different repository; its changes are tracked
+			// by diffing that repository's files, not its go.mod here.
+			continue
+		}
+
+		var old map[string]string
+		switch oldBytes, err := repo.ReadFileAtRef(ctx, ref, rel); {
+		case errors.Is(err, os.ErrNotExist):
+			// The module did not exist at ref; every current requirement is new.
+		case err != nil:
+			errs = append(errs, err)
+			continue
+		default:
+			oldFile, err := modfile.Parse("go.mod", oldBytes, nil)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			old = moduleResolutions(oldFile)
+		}
+
+		// Locally replaced modules resolve to a directory whose changes are tracked
+		// by file diffs, so a go.mod version change must not flag them here.
+		local := localReplacedPaths(mod.file)
+		for path := range diffResolutions(old, moduleResolutions(mod.file)) {
+			if _, ok := local[path]; ok {
+				continue
+			}
+			changed[path] = struct{}{}
+		}
+	}
+
+	return changed, errors.Join(errs...)
+}
+
+// localReplacedPaths returns the set of module paths that f replaces with a local
+// directory.
+func localReplacedPaths(f *modfile.File) map[string]struct{} {
+	local := map[string]struct{}{}
+	for _, r := range f.Replace {
+		if modfile.IsDirectoryPath(r.New.Path) {
+			local[r.Old.Path] = struct{}{}
+		}
+	}
+	return local
+}
+
+// moduleResolutions maps each module path required by f to a token describing how
+// it resolves. A change in the token means the dependency's compiled output could
+// have changed.
+func moduleResolutions(f *modfile.File) map[string]string {
+	res := make(map[string]string, len(f.Require))
+	for _, r := range f.Require {
+		res[r.Mod.Path] = "v=" + r.Mod.Version
+	}
+	// A replace overrides the requirement, so it is applied second.
+	for _, r := range f.Replace {
+		res[r.Old.Path] = "r=" + r.New.Path + "@" + r.New.Version
+	}
+	return res
+}
+
+// diffResolutions returns the module paths whose resolution token differs between
+// old and new, including paths present in only one of them.
+func diffResolutions(old, new map[string]string) map[string]struct{} {
+	changed := map[string]struct{}{}
+	for path, token := range old {
+		if new[path] != token {
+			changed[path] = struct{}{}
+		}
+	}
+	for path, token := range new {
+		if old[path] != token {
+			changed[path] = struct{}{}
+		}
+	}
+	return changed
+}
+
+// coversAny reports whether importPath belongs to any of the given module paths.
+func coversAny(importPath string, modulePaths map[string]struct{}) bool {
+	for modulePath := range modulePaths {
+		if _, ok := moduleCovers(importPath, modulePath); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// closeOverImporters expands seeds to include every package that transitively
+// imports a seed package.
+func closeOverImporters(seeds map[string]struct{}, graph *importGraph) map[string]struct{} {
+	importers := map[string][]string{}
+	for importer, edges := range graph.snapshot() {
+		for _, edge := range edges {
+			if edge.dir != "" {
+				importers[edge.dir] = append(importers[edge.dir], importer)
+			}
+		}
+	}
+
+	affected := make(map[string]struct{}, len(seeds))
+	stack := make([]string, 0, len(seeds))
+	for dir := range seeds {
+		affected[dir] = struct{}{}
+		stack = append(stack, dir)
+	}
+	for len(stack) > 0 {
+		dir := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		for _, importer := range importers[dir] {
+			if _, ok := affected[importer]; !ok {
+				affected[importer] = struct{}{}
+				stack = append(stack, importer)
+			}
+		}
+	}
+	return affected
+}

--- a/internal/pkg/modulefiles/changed_test.go
+++ b/internal/pkg/modulefiles/changed_test.go
@@ -1,0 +1,311 @@
+package modulefiles
+
+import (
+	"context"
+	"go/build"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/iwahbe/helpmakego/internal/pkg/display"
+	"github.com/iwahbe/helpmakego/internal/pkg/log"
+	"github.com/iwahbe/helpmakego/internal/pkg/vcs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type changedTest struct {
+	files  map[string]string // path:content of the working tree
+	runDir string            // entry point relative to files
+
+	changed  []string          // paths, relative to root, that differ since the ref
+	oldFiles map[string]string // repo-relative path:content as of the ref
+
+	includeTestFiles bool
+	includeMod       bool
+	emitPackages     bool
+
+	expected []string
+}
+
+// changedRef is the synthetic revision name the fake repository answers for.
+const changedRef = "REF"
+
+func testChanged(t *testing.T, tt changedTest) {
+	t.Helper()
+
+	ctx := log.New(t.Context(), slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level: slog.LevelWarn,
+	})))
+
+	tmpDir := t.TempDir()
+	for path, content := range tt.files {
+		full := filepath.Join(tmpDir, path)
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0755))
+		require.NoError(t, os.WriteFile(full, []byte(content), 0644))
+	}
+
+	changed := make([]string, len(tt.changed))
+	for i, path := range tt.changed {
+		changed[i] = filepath.Join(tmpDir, path)
+	}
+	oldFiles := map[string][]byte{}
+	for path, content := range tt.oldFiles {
+		oldFiles[path] = []byte(content)
+	}
+	repo := &vcs.Fake{
+		RepoRoot: tmpDir,
+		Changed:  map[string][]string{changedRef: changed},
+		Files:    map[string]map[string][]byte{changedRef: oldFiles},
+	}
+	discover := func(context.Context, string) (vcs.Repo, error) { return repo, nil }
+
+	files, err := findWithModules(ctx, filepath.Join(tmpDir, tt.runDir), FindArgs{
+		TestPaths:    tt.includeTestFiles,
+		ModFiles:     tt.includeMod,
+		GoWork:       true,
+		EmitPackages: tt.emitPackages,
+		ChangedSince: changedRef,
+	}, discover, new(modules), &build.Default)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, tt.expected, display.Relative(ctx, tmpDir, files))
+}
+
+// chainFiles is main -> pkgb -> pkga, all in module example.com/m.
+func chainFiles() map[string]string {
+	return map[string]string{
+		"go.mod": `module example.com/m
+
+go 1.18
+`,
+		"main.go": `package main
+
+import "example.com/m/pkgb"
+
+func main() { _ = pkgb.B() }
+`,
+		"pkgb/b.go": `package pkgb
+
+import "example.com/m/pkga"
+
+func B() string { return pkga.A() }
+`,
+		"pkga/a.go": `package pkga
+
+func A() string { return "a" }
+`,
+	}
+}
+
+func TestChangedLeafPropagatesToImporters(t *testing.T) {
+	t.Parallel()
+	testChanged(t, changedTest{
+		files:        chainFiles(),
+		emitPackages: true,
+		changed:      []string{filepath.Join("pkga", "a.go")},
+		expected:     []string{".", "pkgb", "pkga"},
+	})
+}
+
+func TestChangedRootOnly(t *testing.T) {
+	t.Parallel()
+	testChanged(t, changedTest{
+		files:        chainFiles(),
+		emitPackages: true,
+		changed:      []string{"main.go"},
+		expected:     []string{"."},
+	})
+}
+
+func TestChangedNothing(t *testing.T) {
+	t.Parallel()
+	testChanged(t, changedTest{
+		files:        chainFiles(),
+		emitPackages: true,
+		changed:      nil,
+		expected:     []string{},
+	})
+}
+
+func TestChangedFilesModeIncludesModFiles(t *testing.T) {
+	t.Parallel()
+	testChanged(t, changedTest{
+		files:      chainFiles(),
+		includeMod: true,
+		changed:    []string{filepath.Join("pkga", "a.go")},
+		expected: []string{
+			"go.mod",
+			"main.go",
+			filepath.Join("pkgb", "b.go"),
+			filepath.Join("pkga", "a.go"),
+		},
+	})
+}
+
+func TestChangedEmbedMarksPackage(t *testing.T) {
+	t.Parallel()
+	files := chainFiles()
+	files["pkga/a.go"] = `package pkga
+
+import _ "embed"
+
+//go:embed data.txt
+var data string
+
+func A() string { return data }
+`
+	files["pkga/data.txt"] = "hello"
+
+	testChanged(t, changedTest{
+		files:        files,
+		emitPackages: true,
+		changed:      []string{filepath.Join("pkga", "data.txt")},
+		expected:     []string{".", "pkgb", "pkga"},
+	})
+}
+
+func TestChangedGoModBumpAffectsImporters(t *testing.T) {
+	t.Parallel()
+	files := chainFiles()
+	files["go.mod"] = `module example.com/m
+
+go 1.18
+
+require github.com/ext/lib v1.1.0
+`
+	files["pkga/a.go"] = `package pkga
+
+import _ "github.com/ext/lib"
+
+func A() string { return "a" }
+`
+
+	testChanged(t, changedTest{
+		files:        files,
+		emitPackages: true,
+		changed:      []string{"go.mod"},
+		oldFiles: map[string]string{
+			"go.mod": `module example.com/m
+
+go 1.18
+
+require github.com/ext/lib v1.0.0
+`,
+		},
+		expected: []string{".", "pkgb", "pkga"},
+	})
+}
+
+// TestChangedCrossRepoReplace exercises a local replace whose target lives in a
+// separate repository. The change in that repository is found by diffing it from
+// the tag the entry go.mod pinned at the ref.
+func TestChangedCrossRepoReplace(t *testing.T) {
+	t.Parallel()
+
+	ctx := log.New(t.Context(), slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level: slog.LevelWarn,
+	})))
+
+	tmpDir := t.TempDir()
+	files := map[string]string{
+		"app/go.mod": `module example.com/app
+
+go 1.18
+
+require example.com/lib v1.0.0
+
+replace example.com/lib => ../lib
+`,
+		"app/main.go": `package main
+
+import "example.com/lib/widget"
+
+func main() { _ = widget.W() }
+`,
+		"lib/go.mod": `module example.com/lib
+
+go 1.18
+`,
+		"lib/widget/widget.go": `package widget
+
+import "example.com/lib/helper"
+
+func W() string { return helper.H() }
+`,
+		"lib/helper/helper.go": `package helper
+
+func H() string { return "h" }
+`,
+	}
+	for path, content := range files {
+		full := filepath.Join(tmpDir, path)
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0755))
+		require.NoError(t, os.WriteFile(full, []byte(content), 0644))
+	}
+
+	appRoot := filepath.Join(tmpDir, "app")
+	libRoot := filepath.Join(tmpDir, "lib")
+
+	app := &vcs.Fake{
+		RepoRoot: appRoot,
+		// Nothing changed in the app repository itself.
+		Changed: map[string][]string{changedRef: nil},
+		// The app go.mod pinned example.com/lib v1.0.0 at the ref.
+		Files: map[string]map[string][]byte{changedRef: {"go.mod": []byte(files["app/go.mod"])}},
+	}
+	lib := &vcs.Fake{
+		RepoRoot: libRoot,
+		// widget changed in the lib repository since its v1.0.0 tag.
+		Changed: map[string][]string{
+			"v1.0.0": {filepath.Join(libRoot, "widget", "widget.go")},
+		},
+	}
+	discover := func(_ context.Context, dir string) (vcs.Repo, error) {
+		if dir == libRoot || strings.HasPrefix(dir, libRoot+string(os.PathSeparator)) {
+			return lib, nil
+		}
+		return app, nil
+	}
+
+	result, err := findWithModules(ctx, appRoot, FindArgs{
+		GoWork:       true,
+		EmitPackages: true,
+		ChangedSince: changedRef,
+	}, discover, new(modules), &build.Default)
+	require.NoError(t, err)
+
+	// widget changed, so widget and its importer app are emitted. helper is a
+	// dependency of widget, not an importer, so it is excluded.
+	assert.ElementsMatch(t, []string{"app", filepath.Join("lib", "widget")},
+		display.Relative(ctx, tmpDir, result))
+}
+
+func TestChangedGoModUnchangedExternal(t *testing.T) {
+	t.Parallel()
+	files := chainFiles()
+	files["go.mod"] = `module example.com/m
+
+go 1.18
+
+require github.com/ext/lib v1.0.0
+`
+	files["pkga/a.go"] = `package pkga
+
+import _ "github.com/ext/lib"
+
+func A() string { return "a" }
+`
+
+	// The go.mod is identical at the ref, so nothing is affected.
+	testChanged(t, changedTest{
+		files:        files,
+		emitPackages: true,
+		changed:      nil,
+		oldFiles: map[string]string{
+			"go.mod": files["go.mod"],
+		},
+		expected: []string{},
+	})
+}

--- a/internal/pkg/modulefiles/find.go
+++ b/internal/pkg/modulefiles/find.go
@@ -14,14 +14,13 @@ import (
 	"sync"
 
 	"github.com/iwahbe/helpmakego/internal/pkg/log"
+	"github.com/iwahbe/helpmakego/internal/pkg/vcs"
 	"golang.org/x/mod/modfile"
 )
 
 // Find the set of files that are depended on by the package at root.
 func Find(ctx context.Context, root string, args FindArgs) ([]string, error) {
-	return findWithModules(ctx, root,
-		args.TestPaths, args.ModFiles, args.GoWork, args.EmitPackages,
-		new(modules), &build.Default)
+	return findWithModules(ctx, root, args, vcs.Discover, new(modules), &build.Default)
 }
 
 type FindArgs struct {
@@ -33,28 +32,35 @@ type FindArgs struct {
 	GoWork bool
 	// If packages should be emitted instead of individual files
 	EmitPackages bool
+	// If emitted files/packages should be filtered to only those changed since the REF passed in
+	ChangedSince string
 }
 
 // Find the set of files that are depended on by the package at root.
 func findWithModules(
 	ctx context.Context, root string,
-	testPaths, modFiles, goWork,
-	packagesOnly bool,
+	args FindArgs,
+	discover discoverFunc,
 	modules *modules, importer interface {
 		ImportDir(string, build.ImportMode) (*build.Package, error)
 	},
 ) ([]string, error) {
 	var errs []error
 
-	files := map[string]struct{}{}
 	if os.Getenv("GO111MODULE") == "off" {
 		return nil, fmt.Errorf("go modules disabled")
 	}
 
-	packages, workspace, err := findPackages(ctx, root, testPaths, goWork, modules, importer)
+	packages, workspace, graph, err := findPackages(ctx, root, args.TestPaths, args.GoWork, modules, importer)
 	if err != nil {
 		return nil, err
 	}
+
+	// Collect every discovered package and the files it contributes. When we only
+	// emit package directories and are not filtering by change, the individual
+	// files are never needed, so collecting them is skipped.
+	collectFiles := args.ChangedSince != "" || !args.EmitPackages
+	pkgFiles := map[string]map[string]struct{}{}
 	for pkg, err := range packages {
 		if err != nil {
 			errs = append(errs, err)
@@ -62,20 +68,39 @@ func findWithModules(
 		if pkg == nil {
 			continue
 		}
-
-		errs = append(errs, importPackage(ctx, pkg, testPaths, packagesOnly, func(fileName string) {
-			files[filepath.Join(pkg.Dir, fileName)] = struct{}{}
+		if !collectFiles {
+			pkgFiles[pkg.Dir] = nil
+			continue
+		}
+		contributed := map[string]struct{}{}
+		errs = append(errs, importPackage(ctx, pkg, args.TestPaths, func(fileName string) {
+			contributed[filepath.Join(pkg.Dir, fileName)] = struct{}{}
 		}))
+		pkgFiles[pkg.Dir] = contributed
 	}
 
-	if modFiles {
-		(*sync.Map)(modules).Range(func(_, m any) bool {
-			errs = append(errs, m.(module).addRootFiles(files))
-			return true
-		})
-		if workspace != nil {
-			errs = append(errs, workspace.addRootFiles(files))
+	emit := make(map[string]struct{}, len(pkgFiles))
+	if args.ChangedSince == "" {
+		for dir := range pkgFiles {
+			emit[dir] = struct{}{}
 		}
+	} else if emit, err = affectedPackages(ctx, root, args.ChangedSince, discover, pkgFiles, graph, modules); err != nil {
+		return nil, err
+	}
+
+	files := map[string]struct{}{}
+	for dir := range emit {
+		if args.EmitPackages {
+			files[dir] = struct{}{}
+			continue
+		}
+		for file := range pkgFiles[dir] {
+			files[file] = struct{}{}
+		}
+	}
+
+	if args.ModFiles {
+		errs = append(errs, addModuleFiles(ctx, args.ChangedSince, emit, modules, workspace, files))
 	}
 
 	sortedFiles := make([]string, 0, len(files))
@@ -86,12 +111,49 @@ func findWithModules(
 	return sortedFiles, errors.Join(errs...)
 }
 
-func importPackage(ctx context.Context, pkg *build.Package, includeTests, packagesOnly bool, addFile addFile) error {
+// addModuleFiles adds the go.mod, go.sum, and workspace files that belong to the
+// emitted packages.
+//
+// Without a --changed-since filter every discovered module contributes its root
+// files. With the filter, only modules that own an emitted package do, so that a
+// module with no affected package is not surfaced.
+func addModuleFiles(
+	ctx context.Context, changedSince string, emit map[string]struct{},
+	modules *modules, workspace *goWorkspace, files map[string]struct{},
+) error {
 	var errs []error
-	if packagesOnly {
-		addFile("")
-		return nil
+	if changedSince == "" {
+		for _, m := range (*sync.Map)(modules).Range {
+			errs = append(errs, m.(module).addRootFiles(files))
+
+		}
+		if workspace != nil {
+			errs = append(errs, workspace.addRootFiles(files))
+		}
+		return errors.Join(errs...)
 	}
+
+	seen := map[string]struct{}{}
+	for dir := range emit {
+		mod, err := modules.findGoMod(ctx, dir)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		if _, ok := seen[mod.rootDir]; ok {
+			continue
+		}
+		seen[mod.rootDir] = struct{}{}
+		errs = append(errs, mod.addRootFiles(files))
+	}
+	if workspace != nil && len(emit) > 0 {
+		errs = append(errs, workspace.addRootFiles(files))
+	}
+	return errors.Join(errs...)
+}
+
+func importPackage(ctx context.Context, pkg *build.Package, includeTests bool, addFile addFile) error {
+	var errs []error
 	errs = append(errs, expandEmbeds(ctx, os.DirFS(pkg.Dir), pkg.EmbedPatterns, addFile))
 	if includeTests {
 		// Include test files
@@ -131,11 +193,11 @@ func findPackages(
 	modules *modules, importer interface {
 		ImportDir(string, build.ImportMode) (*build.Package, error)
 	},
-) (iter.Seq2[*build.Package, error], *goWorkspace, error) {
+) (iter.Seq2[*build.Package, error], *goWorkspace, *importGraph, error) {
 	goMod, err := modules.findGoMod(ctx, root)
 	if err != nil {
 		log.Debug(ctx, "unable to find initial go.mod")
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	// Find the go.mod
@@ -158,7 +220,7 @@ func findPackages(
 		if errors.Is(err, errNoGoWorkFound) {
 			log.Debug(ctx, "no go.work found above %s")
 		} else if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		} else {
 			// Apply replaces from go.work
 			for _, r := range goWork.file.Replace {
@@ -201,6 +263,7 @@ func findPackages(
 		return strings.Compare(b.from, a.from)
 	})
 
+	graph := newImportGraph()
 	finder := packageFinder{
 		replaces:     _replaces,
 		includeTests: includeTests,
@@ -208,6 +271,7 @@ func findPackages(
 		importer:     importer,
 		cancel:       cancel,
 		dst:          incoming,
+		edges:        graph,
 	}
 
 	finder.wg.Add(1)
@@ -243,7 +307,7 @@ func findPackages(
 				return
 			}
 		}
-	}, goWork, nil
+	}, goWork, graph, nil
 }
 
 type packageFinder struct {
@@ -265,6 +329,9 @@ type packageFinder struct {
 
 	// seen is a cache of modules already processed.
 	seen sync.Map // Map of string -> struct{}
+
+	// edges records the import graph discovered while walking packages.
+	edges *importGraph
 
 	dst chan<- *build.Package
 
@@ -426,25 +493,21 @@ func (pf *packageFinder) findPackages(ctx context.Context, target string, pkgNam
 	pf.dst <- pkg
 
 	searchImport := func(_import string) {
+		// Record the edge for every occurrence, even repeated or foreign imports,
+		// so the import graph is complete for reverse-dependency analysis.
+		dir, local := pf.resolve(goMod, _import)
+		pf.edges.add(target, _import, dir)
+
+		if !local {
+			log.Debug(ctx, "Skipping foreign import", log.Attr("module", _import))
+			return
+		}
 		if _, ok := pf.seen.LoadOrStore(_import, struct{}{}); ok {
 			log.Debug(ctx, "Skipping repeated import", log.Attr("module", _import))
 			return
 		}
-		rest, isInModule := moduleCovers(_import, goMod.file.Module.Mod.Path)
-		if !isInModule {
-			if replaceTarget, ok := pf.fromReplace(_import); ok {
-				log.Debug(ctx, "Replacing import",
-					log.Attr("from", _import), log.Attr("to", replaceTarget))
-				pf.wg.Add(1)
-				go pf.findPackages(ctx, replaceTarget, _import)
-				return
-			} else {
-				log.Debug(ctx, "Skipping foreign import", log.Attr("module", _import))
-				return
-			}
-		}
 		pf.wg.Add(1)
-		go pf.findPackages(ctx, filepath.Join(goMod.rootDir, rest), _import)
+		go pf.findPackages(ctx, dir, _import)
 	}
 
 	log.Debug(ctx, "finding transitive imports",
@@ -471,6 +534,20 @@ func (pf *packageFinder) findPackages(ctx context.Context, target string, pkgNam
 			searchImport(_import)
 		}
 	}
+}
+
+// resolve maps an import path to the local directory that provides it.
+//
+// It returns the directory and true when the import is part of goMod's module or
+// is satisfied by a local replace, and ("", false) for foreign imports.
+func (pf *packageFinder) resolve(goMod module, _import string) (string, bool) {
+	if rest, ok := moduleCovers(_import, goMod.file.Module.Mod.Path); ok {
+		return filepath.Join(goMod.rootDir, rest), true
+	}
+	if replaceTarget, ok := pf.fromReplace(_import); ok {
+		return replaceTarget, true
+	}
+	return "", false
 }
 
 func (pf *packageFinder) fromReplace(_import string) (string, bool) {

--- a/internal/pkg/vcs/git.go
+++ b/internal/pkg/vcs/git.go
@@ -1,0 +1,98 @@
+package vcs
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// git is a [Repo] backed by the git command line.
+type git struct{ root string }
+
+// newGit constructs a git [Repo] for the repository containing dir.
+//
+// It resolves dir to the repository's top level so that paths reported by git
+// are relative to root.
+func newGit(ctx context.Context, dir string) (Repo, error) {
+	out, err := run(ctx, dir, "rev-parse", "--show-toplevel")
+	if err != nil {
+		return nil, err
+	}
+	return git{root: filepath.Clean(strings.TrimSpace(string(out)))}, nil
+}
+
+func (g git) Root() string { return g.root }
+
+func (g git) ChangedFiles(ctx context.Context, ref string) ([]string, error) {
+	// The two commands are independent, so run them concurrently.
+	var diff, untracked []byte
+	var diffErr, untrackedErr error
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		// diff reports the net difference between ref and the working tree, covering
+		// intervening commits as well as staged and unstaged changes.
+		diff, diffErr = run(ctx, g.root, "diff", "-z", "--name-only", ref, "--")
+	}()
+	go func() {
+		defer wg.Done()
+		// ls-files adds untracked files, which diff does not report.
+		untracked, untrackedErr = run(ctx, g.root, "ls-files", "-z", "--others", "--exclude-standard")
+	}()
+	wg.Wait()
+	if err := errors.Join(diffErr, untrackedErr); err != nil {
+		return nil, err
+	}
+
+	seen := map[string]struct{}{}
+	var files []string
+	for _, rel := range append(splitNUL(diff), splitNUL(untracked)...) {
+		abs := filepath.Join(g.root, rel)
+		if _, ok := seen[abs]; ok {
+			continue
+		}
+		seen[abs] = struct{}{}
+		files = append(files, abs)
+	}
+	return files, nil
+}
+
+func (g git) ReadFileAtRef(ctx context.Context, ref, path string) ([]byte, error) {
+	out, err := run(ctx, g.root, "show", ref+":"+filepath.ToSlash(path))
+	if err != nil {
+		// git reports a missing path on stderr, which run folds into err.
+		if strings.Contains(err.Error(), "does not exist") ||
+			strings.Contains(err.Error(), "exists on disk, but not in") {
+			return nil, fmt.Errorf("%s at %s: %w", path, ref, os.ErrNotExist)
+		}
+		return nil, err
+	}
+	return out, nil
+}
+
+func run(ctx context.Context, dir string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "git", append([]string{"-C", dir}, args...)...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("git %s: %w: %s",
+			strings.Join(args, " "), err, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.Bytes(), nil
+}
+
+func splitNUL(b []byte) []string {
+	b = bytes.TrimRight(b, "\x00")
+	if len(b) == 0 {
+		return nil
+	}
+	return strings.Split(string(b), "\x00")
+}

--- a/internal/pkg/vcs/git_test.go
+++ b/internal/pkg/vcs/git_test.go
@@ -1,0 +1,118 @@
+package vcs
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// gitRepo initializes a git repository in a temporary directory with a single
+// committed file and returns its root.
+func gitRepo(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Fatalf("could not resolve git: %s", err.Error())
+	}
+
+	// git rev-parse resolves symlinks, so resolve the temp dir up front to keep
+	// the paths it reports comparable with the ones the test constructs.
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
+	gitDo := func(args ...string) {
+		t.Helper()
+		cmd := exec.CommandContext(t.Context(), "git", args...)
+		cmd.Dir = root
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v: %s", args, out)
+	}
+
+	gitDo("init")
+	gitDo("config", "user.email", "test@example.com")
+	gitDo("config", "user.name", "Test")
+	writeFile(t, root, "committed.txt", "original")
+	gitDo("add", "committed.txt")
+	gitDo("commit", "-m", "initial")
+
+	return root
+}
+
+func writeFile(t *testing.T, root, rel, content string) {
+	t.Helper()
+	full := filepath.Join(root, rel)
+	require.NoError(t, os.MkdirAll(filepath.Dir(full), 0755))
+	require.NoError(t, os.WriteFile(full, []byte(content), 0644))
+}
+
+func TestGitChangedFiles(t *testing.T) {
+	t.Parallel()
+	root := gitRepo(t)
+
+	repo, err := Discover(t.Context(), root)
+	require.NoError(t, err)
+	assert.Equal(t, root, repo.Root())
+
+	// A clean tree at HEAD reports nothing.
+	changed, err := repo.ChangedFiles(t.Context(), "HEAD")
+	require.NoError(t, err)
+	assert.Empty(t, changed)
+
+	// Modify a tracked file and add an untracked one.
+	writeFile(t, root, "committed.txt", "modified")
+	writeFile(t, root, "pkg/new.txt", "new")
+
+	changed, err = repo.ChangedFiles(t.Context(), "HEAD")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{
+		filepath.Join(root, "committed.txt"),
+		filepath.Join(root, "pkg", "new.txt"),
+	}, changed)
+}
+
+func TestGitChangedFilesNetRevert(t *testing.T) {
+	t.Parallel()
+	root := gitRepo(t)
+
+	repo, err := Discover(t.Context(), root)
+	require.NoError(t, err)
+
+	// Reverting a tracked file to its HEAD contents leaves no net change.
+	writeFile(t, root, "committed.txt", "original")
+	changed, err := repo.ChangedFiles(t.Context(), "HEAD")
+	require.NoError(t, err)
+	assert.Empty(t, changed)
+}
+
+func TestGitReadFileAtRef(t *testing.T) {
+	t.Parallel()
+	root := gitRepo(t)
+
+	repo, err := Discover(t.Context(), root)
+	require.NoError(t, err)
+
+	// The working tree differs from HEAD, but the ref still sees the original.
+	writeFile(t, root, "committed.txt", "modified")
+	content, err := repo.ReadFileAtRef(t.Context(), "HEAD", "committed.txt")
+	require.NoError(t, err)
+	assert.Equal(t, "original", string(content))
+}
+
+func TestGitReadFileAtRefMissing(t *testing.T) {
+	t.Parallel()
+	root := gitRepo(t)
+
+	repo, err := Discover(t.Context(), root)
+	require.NoError(t, err)
+
+	_, err = repo.ReadFileAtRef(t.Context(), "HEAD", "absent.txt")
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestDiscoverNotARepository(t *testing.T) {
+	t.Parallel()
+	_, err := Discover(t.Context(), t.TempDir())
+	assert.ErrorIs(t, err, ErrNotARepository)
+}

--- a/internal/pkg/vcs/mock.go
+++ b/internal/pkg/vcs/mock.go
@@ -1,0 +1,34 @@
+package vcs
+
+import (
+	"context"
+	"fmt"
+	"os"
+)
+
+// Fake is an in-memory [Repo] for tests. The zero value is not usable; set
+// RepoRoot at least.
+type Fake struct {
+	// RepoRoot is returned by Root.
+	RepoRoot string
+	// Changed maps a ref to the absolute paths ChangedFiles reports for it.
+	Changed map[string][]string
+	// Files maps a ref to the file contents ReadFileAtRef reports for it, keyed
+	// by repository-relative path.
+	Files map[string]map[string][]byte
+}
+
+var _ Repo = (*Fake)(nil)
+
+func (f *Fake) Root() string { return f.RepoRoot }
+
+func (f *Fake) ChangedFiles(_ context.Context, ref string) ([]string, error) {
+	return f.Changed[ref], nil
+}
+
+func (f *Fake) ReadFileAtRef(_ context.Context, ref, path string) ([]byte, error) {
+	if content, ok := f.Files[ref][path]; ok {
+		return content, nil
+	}
+	return nil, fmt.Errorf("%s at %s: %w", path, ref, os.ErrNotExist)
+}

--- a/internal/pkg/vcs/vcs.go
+++ b/internal/pkg/vcs/vcs.go
@@ -1,0 +1,93 @@
+// Package vcs abstracts over a version control system so that helpmakego can ask
+// what has changed since a given revision.
+//
+// Go modules may live in repositories managed by Git, Mercurial, and others, so
+// callers depend on the [Repo] interface rather than any single tool. The
+// interface is small enough to mock; see [Fake] for an in-memory implementation
+// suitable for tests.
+package vcs
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+// Repo is a version control repository rooted at a single directory.
+type Repo interface {
+	// Root returns the absolute path to the root of the repository.
+	Root() string
+
+	// ChangedFiles returns the absolute paths of every file that differs between
+	// ref and the current working tree.
+	//
+	// This is the net difference and includes files changed by intervening
+	// commits, uncommitted changes (both staged and unstaged), and untracked
+	// files. A file changed in an intervening commit but reverted to its ref
+	// contents is not reported.
+	ChangedFiles(ctx context.Context, ref string) ([]string, error)
+
+	// ReadFileAtRef returns the contents of the file at path, relative to the
+	// repository root, as of ref.
+	//
+	// It returns an error wrapping [os.ErrNotExist] if the file did not exist at
+	// ref.
+	ReadFileAtRef(ctx context.Context, ref, path string) ([]byte, error)
+}
+
+// ErrNotARepository is returned by [Discover] when dir is not contained in any
+// supported version control repository.
+var ErrNotARepository = errors.New("not in a version control repository")
+
+// ErrUnsupportedVCS is returned by [Discover] when dir is contained in a
+// repository whose version control system helpmakego does not yet support.
+var ErrUnsupportedVCS = errors.New("unsupported version control system")
+
+// Discover finds the version control repository that contains dir.
+//
+// It walks up from dir looking for a known repository marker. It returns
+// [ErrNotARepository] if no marker is found and [ErrUnsupportedVCS] if a marker
+// for an unsupported system is found.
+func Discover(ctx context.Context, dir string) (Repo, error) {
+	dir, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	for {
+		switch marker, err := markerAt(dir); {
+		case err != nil:
+			return nil, err
+		case marker == ".git":
+			return newGit(ctx, dir)
+		case marker != "":
+			return nil, ErrUnsupportedVCS
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return nil, ErrNotARepository
+		}
+		dir = parent
+	}
+}
+
+// markerAt returns the name of the version control marker present in dir, or the
+// empty string if none is present.
+func markerAt(dir string) (string, error) {
+	// Markers for systems we do not yet support are still detected so that
+	// Discover can report ErrUnsupportedVCS rather than walking past the
+	// enclosing repository.
+	for _, marker := range []string{".git", ".hg", ".svn", ".bzr", ".fossil"} {
+		switch _, err := os.Stat(filepath.Join(dir, marker)); {
+		case err == nil:
+			return marker, nil
+		case errors.Is(err, os.ErrNotExist):
+			continue
+		default:
+			return "", err
+		}
+	}
+	return "", nil
+}


### PR DESCRIPTION
Add the ability to list files that have changed since a VCS ref. The goal is to enable testing exactly the packages that are effected by the current VCS change:

```shell
𝛌 go test $(helpmakego . --packages  --changed-since master --abs)
```

A system like this is a necessary precondition for a "test my changes" command in a large and quickly changing system. 

The built-in `go test` caching doesn't cut it in a repo where multiple people are quickly changing parts of the codebase unrelated to your changes. Every `git pull` would force re-runs of tests that have tested green on the default branch already.

Instead, we need a test set based on what tests could be effected by the current change, and that's what `--changed-since` provides.